### PR TITLE
Reduce trait requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ keywords = ["tree", "btree", "btreemap", "index", "indexing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = ["serde"]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@ use std::fmt::Debug;
 
 use methods::iter::{IndexTreeIterator, IndexTreeKeys, IndexTreeSetIterator, IndexTreeValues};
 // use methods::iter::{IndexTreeIterator, IndexTreeKeys, IndexTreeValues};
-use serde::{Deserialize, Serialize};
 use stc::{
     Node,
     Output::{KeyExists, NewKeyPointer},
 };
 
 /// The 'Set' IndexTree data structure
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexTreeSet<K> {
     pub map: IndexTreeMap<K, ()>,
 }
@@ -389,7 +389,8 @@ impl<K: Default + Ord + Clone> IndexTreeSet<K> {
 }
 
 /// The 'Map' IndexTree data structure
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexTreeMap<K, V> {
     pub root: Box<Node<K, V>>,
     pub size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub struct IndexTreeSet<K> {
     pub map: IndexTreeMap<K, ()>,
 }
 
-impl<K: Default> IndexTreeSet<K> {
+impl<K> IndexTreeSet<K> {
     /// Makes a new, empty IndexTreeSet.
     ///
     /// Does not allocate anything on its own.
@@ -50,7 +50,7 @@ impl<K: Default> IndexTreeSet<K> {
     }
 }
 
-impl<K: Default> IndexTreeSet<K> {
+impl<K> IndexTreeSet<K> {
     /// Clears the map, removing all elements.
     ///
     /// Does not allocate anything on its own.
@@ -254,7 +254,7 @@ impl<K: Ord> IndexTreeSet<K> {
     }
 }
 
-impl<K: Default + Ord + Clone + Debug> IndexTreeSet<K> {
+impl<K: Ord + Clone> IndexTreeSet<K> {
     /// Inserts a key into the set.  
     ///
     /// # Example
@@ -296,7 +296,7 @@ impl<K> IndexTreeSet<K> {
     }
 }
 
-impl<K: Default + Ord + Clone> IndexTreeSet<K> {
+impl<K: Ord + Clone> IndexTreeSet<K> {
     /// Removes an item from the map from its corresponding key, returning the key-value pair that was previously in the map.
     ///
     /// # Example
@@ -315,7 +315,7 @@ impl<K: Default + Ord + Clone> IndexTreeSet<K> {
     }
 }
 
-impl<K: Default + Ord + Clone> IndexTreeSet<K> {
+impl<K: Ord + Clone> IndexTreeSet<K> {
     /// Removes an item from the map from its corresponding index, returning the key-value pair that was previously in the map.
     ///
     /// # Example
@@ -334,7 +334,7 @@ impl<K: Default + Ord + Clone> IndexTreeSet<K> {
     }
 }
 
-impl<K: Default + Ord + Clone> IndexTreeSet<K> {
+impl<K: Ord + Clone> IndexTreeSet<K> {
     /// Splits the map into two at the given key. Returns everything after the given key, including the key.
     ///
     /// # Example
@@ -389,14 +389,14 @@ impl<K: Default + Ord + Clone> IndexTreeSet<K> {
 }
 
 /// The 'Map' IndexTree data structure
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexTreeMap<K, V> {
     pub root: Box<Node<K, V>>,
     pub size: usize,
 }
 
-impl<K: Default, V: Default> IndexTreeMap<K, V> {
+impl<K, V> IndexTreeMap<K, V> {
     /// Makes a new, empty IndexTreeMap.
     ///
     /// Does not allocate anything on its own.
@@ -413,13 +413,20 @@ impl<K: Default, V: Default> IndexTreeMap<K, V> {
     ///
     /// ```    
     pub fn new() -> IndexTreeMap<K, V> {
-        let mut tree = IndexTreeMap::default();
-        tree.root.leaf = true;
-        tree
+        IndexTreeMap::default()
     }
 }
 
-impl<K: Default, V: Default> IndexTreeMap<K, V> {
+impl<K, V> Default for IndexTreeMap<K, V> {
+    fn default() -> Self {
+        IndexTreeMap {
+            root: Node::new(),
+            size: 0,
+        }
+    }
+}
+
+impl<K, V> IndexTreeMap<K, V> {
     /// Clears the map, removing all elements.
     ///
     /// Does not allocate anything on its own.
@@ -437,12 +444,7 @@ impl<K: Default, V: Default> IndexTreeMap<K, V> {
     /// assert!(map.is_empty());
     /// ```
     pub fn clear(&mut self) {
-        self.root = Box::new(Node {
-            keys: Default::default(),
-            pointers: Default::default(),
-            n: 0,
-            leaf: true,
-        });
+        self.root = Node::new();
         self.size = 0
     }
 }
@@ -788,7 +790,7 @@ impl<K: Ord, V> IndexTreeMap<K, V> {
     }
 }
 
-impl<K: Default + Ord + Clone + Debug, V: Default + Clone + Debug> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Inserts a key-value pair into the map.  
     ///
     /// # Example
@@ -881,7 +883,7 @@ impl<K, V> IndexTreeMap<K, V> {
     }
 }
 
-impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Removes an item from the map from its corresponding key, returning the key-value pair that was previously in the map.
     ///
     /// # Example
@@ -906,7 +908,7 @@ impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
     }
 }
 
-impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Removes an item from the map from its corresponding index, returning the key-value pair that was previously in the map.
     ///
     /// # Example
@@ -931,7 +933,7 @@ impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
     }
 }
 
-impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Replaces an item from the map from it's corresponding key, returning the key-value pair was previously in the map.
     ///
     /// # Example
@@ -950,7 +952,7 @@ impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
     }
 }
 
-impl<K: Default + Ord + Clone + Debug, V: Default + Clone + Debug> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Replaces an item from the map from it's corresponding index, returning the key-value pair was previously in the map.
     ///
     /// # Example
@@ -972,7 +974,7 @@ impl<K: Default + Ord + Clone + Debug, V: Default + Clone + Debug> IndexTreeMap<
     }
 }
 
-impl<K: Default + Ord + Clone, V: Default + Clone> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     /// Splits the map into two at the given key. Returns everything after the given key, including the key.
     ///
     /// # Example

--- a/src/methods/insert.rs
+++ b/src/methods/insert.rs
@@ -6,12 +6,9 @@ use crate::{
     },
     KEY_ARRAY,
 };
-use std::{
-    cmp::Ordering::{Equal, Greater, Less},
-    fmt::Debug,
-};
+use std::cmp::Ordering::{Equal, Greater, Less};
 
-impl<K: Default + Clone + Ord + Debug, V: Default + Clone + Debug> Node<K, V> {
+impl<K: Ord + Clone, V: Clone> Node<K, V> {
     pub fn insert(&mut self, key: K, value: V) -> Output<K, V> {
         // if node is a leaf then the node has no pointers
 

--- a/src/methods/iter.rs
+++ b/src/methods/iter.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use crate::{IndexTreeMap, IndexTreeSet};
 
 //Iterator
@@ -8,7 +6,7 @@ pub struct IndexTreeIterator<'a, K, V> {
     pub index: usize,
 }
 
-impl<'a, K: Default + Ord + Clone, V: Default + Clone> Iterator for IndexTreeIterator<'a, K, V> {
+impl<'a, K: Ord + Clone, V: Clone> Iterator for IndexTreeIterator<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -26,7 +24,7 @@ pub struct IndexTreeSetIterator<'a, K> {
     pub index: usize,
 }
 
-impl<'a, K: Default + Ord + Clone> Iterator for IndexTreeSetIterator<'a, K> {
+impl<'a, K: Ord + Clone> Iterator for IndexTreeSetIterator<'a, K> {
     type Item = &'a K;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -43,7 +41,7 @@ impl<'a, K: Default + Ord + Clone> Iterator for IndexTreeSetIterator<'a, K> {
 //     pub tree: IndexTreeMap<K, V>,
 // }
 
-// impl<K: Default + Ord + Clone, V: Default + Clone> IntoIterator for IndexTreeMap<K, V> {
+// impl<K: Ord + Clone, V: Clone> IntoIterator for IndexTreeMap<K, V> {
 //     type Item = (K, V);
 //     type IntoIter = IndexTreeIntoIterator<K, V>;
 
@@ -67,7 +65,7 @@ impl<'a, K: Default + Ord + Clone> Iterator for IndexTreeSetIterator<'a, K> {
 //     }
 // }
 
-// impl<K: Default + Ord + Clone, V: Default + Clone> Iterator for IndexTreeIntoIterator<K, V> {
+// impl<K: Ord + Clone, V: Clone> Iterator for IndexTreeIntoIterator<K, V> {
 //     type Item = (K, V);
 
 //     fn next(&mut self) -> Option<Self::Item> {
@@ -79,13 +77,13 @@ impl<'a, K: Default + Ord + Clone> Iterator for IndexTreeSetIterator<'a, K> {
 // }
 
 // FromIter
-impl<K: Default + Ord + Clone + Debug, V: Default + Clone + Debug> IndexTreeMap<K, V> {
+impl<K: Ord + Clone, V: Clone> IndexTreeMap<K, V> {
     fn add(&mut self, item: (K, V)) {
         self.insert(item.0, item.1);
     }
 }
 
-impl<K: Default + Ord + Clone + Debug, V: Default + Clone + Debug> FromIterator<(K, V)>
+impl<K: Ord + Clone, V: Clone> FromIterator<(K, V)>
     for IndexTreeMap<K, V>
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
@@ -105,7 +103,7 @@ pub struct IndexTreeKeys<'a, K, V> {
     pub index: usize,
 }
 
-impl<'a, K: Default + Ord + Clone, V: Default + Clone> Iterator for IndexTreeKeys<'a, K, V> {
+impl<'a, K: Ord + Clone, V: Clone> Iterator for IndexTreeKeys<'a, K, V> {
     type Item = &'a K;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -123,7 +121,7 @@ pub struct IndexTreeValues<'a, K, V> {
     pub index: usize,
 }
 
-impl<'a, K: Default + Ord + Clone, V: Default + Clone> Iterator for IndexTreeValues<'a, K, V> {
+impl<'a, K: Ord + Clone, V: Clone> Iterator for IndexTreeValues<'a, K, V> {
     type Item = &'a V;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/methods/search.rs
+++ b/src/methods/search.rs
@@ -1,7 +1,7 @@
 use crate::stc::Node;
 use std::cmp::Ordering::{Equal, Greater, Less};
 
-impl<K: Default + Clone + Ord, V: Default + Clone> Node<K, V> {
+impl<K: Clone + Ord, V: Clone> Node<K, V> {
     pub fn binary_search(&self, key: &K) -> Result<usize, usize> {
         if self.n == 0 {
             Err(0)

--- a/src/methods/split.rs
+++ b/src/methods/split.rs
@@ -5,7 +5,7 @@ use crate::{
     KEY_ARRAY, POINTER_ARRAY,
 };
 
-impl<K: Default + Ord + Clone, V: Default + Clone> Node<K, V> {
+impl<K: Ord + Clone, V: Clone> Node<K, V> {
     pub fn split_off(&mut self, key: &K) -> Option<Pointer<K, V>> {
         for (index, item) in self.keys.iter().enumerate() {
             if let Some(item) = item {
@@ -223,15 +223,16 @@ impl<K: Default + Ord + Clone, V: Default + Clone> Node<K, V> {
     }
 }
 
-impl<K: Default + Clone, V: Default + Clone> Node<K, V> {
+impl<K: Clone, V: Clone> Node<K, V> {
     pub fn split_root(&mut self) {
         let new_root_key = self.keys[KEY_ARRAY / 2].take();
-        let mut new_node: Box<Node<K, V>> = Node::new();
-        new_node.n = KEY_ARRAY / 2;
-        new_node.leaf = self.leaf;
 
-        let mut left_node = new_node.clone();
-        let mut right_node = new_node;
+        let mut left_node = Node::new();
+        left_node.n = KEY_ARRAY / 2;
+        left_node.leaf = self.leaf;
+        let mut right_node = Node::new();
+        right_node.n = KEY_ARRAY / 2;
+        right_node.leaf = self.leaf;
 
         let mut left_counter = 0;
         let mut right_counter = 0;

--- a/src/stc.rs
+++ b/src/stc.rs
@@ -1,10 +1,9 @@
 use std::fmt::Debug;
 
-use serde::{Deserialize, Serialize};
-
 use crate::{KEY_ARRAY, POINTER_ARRAY};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Output<K, V> {
     #[default]
     Null,
@@ -13,7 +12,8 @@ pub enum Output<K, V> {
     NewKeyPointer(Option<Box<Item<K, V>>>, Option<Pointer<K, V>>),
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pointer<K, V> {
     pub child: Box<Node<K, V>>,
     pub counter: usize,
@@ -28,7 +28,8 @@ impl<K: Default, V: Default> Pointer<K, V> {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node<K, V> {
     pub keys: [Option<Box<Item<K, V>>>; KEY_ARRAY],
     pub n: usize, // the number of keys stored in the node
@@ -70,7 +71,8 @@ impl<K, V> Node<K, V> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Item<K, V> {
     pub key: Box<K>,
     pub value: Box<V>,

--- a/src/stc.rs
+++ b/src/stc.rs
@@ -19,7 +19,7 @@ pub struct Pointer<K, V> {
     pub counter: usize,
 }
 
-impl<K: Default, V: Default> Pointer<K, V> {
+impl<K, V> Pointer<K, V> {
     pub fn new() -> Pointer<K, V> {
         Pointer {
             child: Node::new(),
@@ -28,7 +28,7 @@ impl<K: Default, V: Default> Pointer<K, V> {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Node<K, V> {
     pub keys: [Option<Box<Item<K, V>>>; KEY_ARRAY],
@@ -37,9 +37,20 @@ pub struct Node<K, V> {
     pub pointers: [Option<Pointer<K, V>>; POINTER_ARRAY],
 }
 
-impl<K: Default, V: Default> Node<K, V> {
+impl<K, V> Node<K, V> {
     pub fn new() -> Box<Node<K, V>> {
         Box::default()
+    }
+}
+
+impl<K, V> Default for Box<Node<K, V>> {
+    fn default() -> Self {
+        Box::new(Node {
+            keys: Default::default(),
+            pointers: Default::default(),
+            n: 0,
+            leaf: true,
+        })
     }
 }
 

--- a/tests/map_tests.rs
+++ b/tests/map_tests.rs
@@ -714,4 +714,12 @@ pub mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_values_without_traits() {
+        #[derive(Clone)]
+        struct Value();
+        let mut map: IndexTreeMap<u64, Value> = IndexTreeMap::default();
+        map.insert(1, Value());
+    }
 }


### PR DESCRIPTION
- **Make serde support optional**: hide it behind a `serde` feature flag. For
  now, make the feature flag enabled by default; the next semver-breaking
  release can remove the `default` feature and let users depend on the `serde`
  feature if they need it.

- **Stop requiring `Default` and `Debug` for keys and values**: All the methods
  can be implemented without these traits, so make the structures more flexible
  about what key and value types they accept.
